### PR TITLE
Add @objc attributes to the configurations properties

### DIFF
--- a/OpalImagePicker/Source/OpalImagePickerConfiguration.swift
+++ b/OpalImagePicker/Source/OpalImagePickerConfiguration.swift
@@ -14,36 +14,36 @@ public class OpalImagePickerConfiguration: NSObject {
     var updateStrings: ((OpalImagePickerConfiguration) -> Void)?
     
     /// Localized navigation title. Defaults to "Photos".
-    public var navigationTitle: String? {
+    @objc public var navigationTitle: String? {
         didSet {
             updateStrings?(self)
         }
     }
     
     /// Localized library segment title. Only displays when using external URLs in `UISegmentedControl`.
-    public var librarySegmentTitle: String? {
+    @objc public var librarySegmentTitle: String? {
         didSet {
             updateStrings?(self)
         }
     }
     
     /// Localized 'Cancel' button text.
-    public var cancelButtonTitle: String? {
+    @objc public var cancelButtonTitle: String? {
         didSet {
             updateStrings?(self)
         }
     }
     
     /// Localized 'Done' button text.
-    public var doneButtonTitle: String? {
+    @objc public var doneButtonTitle: String? {
         didSet {
             updateStrings?(self)
         }
     }
     
     /// Localized maximum selections allowed error message displayed to the user.
-    public var maximumSelectionsAllowedMessage: String?
+    @objc public var maximumSelectionsAllowedMessage: String?
     
     /// Localized "OK" string.
-    public var okayString: String?
+    @objc public var okayString: String?
 }


### PR DESCRIPTION
The `OpalImagePickerConfiguration` isn't usable from Objective-C because the properties aren't defined with `@objc`.