### PR TITLE
fix iOS11 warning with condition

### DIFF
--- a/OpalImagePicker/Source/OpalImagePickerRootViewController.swift
+++ b/OpalImagePicker/Source/OpalImagePickerRootViewController.swift
@@ -211,11 +211,17 @@ open class OpalImagePickerRootViewController: UIViewController {
             tabSegmentedControl.setTitle(title, forSegmentAt: 1)
         }
         
+        var topLayout = topLayoutGuide
+        
+        if #available(iOS 11.0, *) {
+            topLayout = view.safeAreaLayoutGuide.topAnchor as! UILayoutSupport
+        }
+        
         NSLayoutConstraint.activate([
-            toolbar.constraintEqualTo(with: topLayoutGuide, receiverAttribute: .top, otherAttribute: .bottom),
+            toolbar.constraintEqualTo(with: topLayout, receiverAttribute: .top, otherAttribute: .bottom),
             toolbar.constraintEqualTo(with: view, attribute: .left),
             toolbar.constraintEqualTo(with: view, attribute: .right)
-            ])
+        ])
     }
     
     private func fetchPhotos() {


### PR DESCRIPTION
Solution 1 for:

> 'topLayoutGuide' was deprecated in iOS 11.0: Use view.safeAreaLayoutGuide.topAnchor instead of topLayoutGuide.bottomAnchor

Check https://github.com/opalorange/OpalImagePicker/pull/63